### PR TITLE
AURO MIGRATION: Update node to v22

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -70,7 +70,7 @@ branches:
         # Required. Require branches to be up to date before merging.
         strict: true
         # Required. The list of status checks to require in order to merge into this branch
-        contexts: ["test (18.x)", "test (20.x)", "license/cla"]
+        contexts: ["test (20.x)", "test (22.x)", "license/cla"]
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: false
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.

--- a/.github/workflows/testPublish.yml
+++ b/.github/workflows/testPublish.yml
@@ -2,6 +2,7 @@ name: Test and publish
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 
+
 # events but only for the main branch
 on:
   push:
@@ -16,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +40,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - run: npm ci
       - run: npm run build:release
       - uses: cycjimmy/semantic-release-action@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-nav",
-  "version": "2.2.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-nav",
-      "version": "2.2.0",
+      "version": "2.3.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -64,7 +64,7 @@
         "yaml-lint": "^1.7.0"
       },
       "engines": {
-        "node": "18.x || 20.x"
+        "node": "^20.x || ^22.x "
       },
       "peerDependencies": {
         "@alaskaairux/icons": "^4.44.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "main": "index.js",
   "license": "Apache-2.0",
   "engines": {
-    "node": "18.x || 20.x"
+    "node": "^20.x || ^22.x "
   },
   "dependencies": {
     "@aurodesignsystem/auro-button": "^8.1.2",


### PR DESCRIPTION
Resolves AlaskaAirlines/auro-templates#6

## Summary by Sourcery

Update Node to v22 and add team access settings.

Build:
- Update Node version to 22.x.

CI:
- Update CI to test on Node version 22.x.

Documentation:
- Update contributing guidelines with innersource flow guide and conventional commit details.