### PR TITLE
fix: add conditional to prevent default in breadcrumb and anchorlink

### DIFF
--- a/src/auro-anchorlink.js
+++ b/src/auro-anchorlink.js
@@ -22,7 +22,7 @@ import { AuroHyperlink } from "@aurodesignsystem/auro-hyperlink/src/auro-hyperli
 export class AuroAnchorlink extends AuroHyperlink {
   static get properties() {
     return {
-      // ...super.properties,
+      ...super.properties,
       active: {
         type: Boolean,
         reflect: true
@@ -68,7 +68,9 @@ export class AuroAnchorlink extends AuroHyperlink {
 
     this.addEventListener('click', (evt) => {
       // Prevents from href from being followed (this is used for testing)
-      evt.preventDefault();
+      if (evt.currentTarget.href && evt.currentTarget.href.startsWith("#")) {
+        evt.preventDefault();
+      }
       this.active = true;
     });
   }

--- a/src/auro-breadcrumb.js
+++ b/src/auro-breadcrumb.js
@@ -41,7 +41,9 @@ export class AuroBreadcrumb extends AuroHyperlink {
 
     this.addEventListener('click', (evt) => {
       // Prevents from href from being followed (this is used for testing)
-      evt.preventDefault();
+      if (evt.currentTarget.href && evt.currentTarget.href.startsWith("#")) {
+        evt.preventDefault();
+      }
       this.active = true;
     });
   }


### PR DESCRIPTION
# Alaska Airlines Pull Request

to keep the navigation working as expected with id reference and also with href links we added a conditional to check if the href provided is a reference or a link this way we can prevent default if needed and keep the logic working as expected

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Only prevent default click for hrefs starting with '#' in AuroAnchorlink and AuroBreadcrumb to allow external link navigation