### PR TITLE
Fix mobile breadcrumb behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,18 @@ The following sections are editable by making changes to the following files:
 <!-- AURO-GENERATED-CONTENT This file is to be used for any additional content that should be included in the README.md which is specific to this component. -->
 <!-- AURO-GENERATED-CONTENT:END -->
 
-## UI development browser support
+## Use Cases
 
-<!-- AURO-GENERATED-CONTENT:START (REMOTE:url=https://raw.githubusercontent.com/AlaskaAirlines/auro-templates/main/templates/default/partials/browserSupport.md) -->
-For the most up to date information on [UI development browser support](https://auro.alaskaair.com/support/browsersSupport)
-
+<!-- AURO-GENERATED-CONTENT:START (FILE:src=./docs/partials/useCases.md) -->
+<!-- The below content is automatically added from ./docs/partials/useCases.md -->
+The `<auro-nav>` element acts as a container for a series of links representing a level of depth in the site content. 
+The `<auro-nav>` element should only be used for multi-page projects that have 3 to 5 levels of page depth.
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## Install
 
 <!-- AURO-GENERATED-CONTENT:START (REMOTE:url=https://raw.githubusercontent.com/AlaskaAirlines/auro-templates/main/templates/default/partials/usage/componentInstall.md) -->
-[![Build Status](https://img.shields.io/github/actions/workflow/status/AlaskaAirlines/auro-nav/testPublish.yml?style=for-the-badge)](https://github.com/AlaskaAirlines/auro-nav/actions/workflows/testPublish.yml)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/AlaskaAirlines/auro-nav/release.yml?style=for-the-badge)](https://github.com/AlaskaAirlines/auro-nav/actions/workflows/release.yml)
 [![See it on NPM!](https://img.shields.io/npm/v/@aurodesignsystem/auro-nav?style=for-the-badge&color=orange)](https://www.npmjs.com/package/@aurodesignsystem/auro-nav)
 [![License](https://img.shields.io/npm/l/@aurodesignsystem/auro-nav?color=blue&style=for-the-badge)](https://www.apache.org/licenses/LICENSE-2.0)
 ![ESM supported](https://img.shields.io/badge/ESM-compatible-FFE900?style=for-the-badge)
@@ -49,17 +50,10 @@ $ npm i @aurodesignsystem/auro-nav
 
 <!-- AURO-GENERATED-CONTENT:END -->
 
-### Design Token CSS Custom Property dependency
-
-<!-- AURO-GENERATED-CONTENT:START (REMOTE:url=https://raw.githubusercontent.com/AlaskaAirlines/auro-templates/main/templates/default/partials/development/designTokens.md) -->
-The use of any Auro custom element has a dependency on the [Auro Design Tokens](https://auro.alaskaair.com/getting-started/developers/design-tokens).
-
-<!-- AURO-GENERATED-CONTENT:END -->
-
-### Define dependency in project component
+### Define Dependency in Project
 
 <!-- AURO-GENERATED-CONTENT:START (REMOTE:url=https://raw.githubusercontent.com/AlaskaAirlines/auro-templates/main/templates/default/partials/usage/componentImportDescription.md) -->
-Defining the component dependency within each component that is using the `<auro-nav>` component.
+Defining the dependency within each project that is using the `<auro-nav>` component.
 
 <!-- AURO-GENERATED-CONTENT:END -->
 <!-- AURO-GENERATED-CONTENT:START (REMOTE:url=https://raw.githubusercontent.com/AlaskaAirlines/auro-templates/main/templates/default/partials/usage/componentImport.md) -->
@@ -69,22 +63,8 @@ import "@aurodesignsystem/auro-nav";
 ```
 
 <!-- AURO-GENERATED-CONTENT:END -->
-**Reference component in HTML**
-<!-- AURO-GENERATED-CONTENT:START (CODE:src=./apiExamples/basic.html) -->
-<!-- The below code snippet is automatically added from ./apiExamples/basic.html -->
 
-```html
-<auro-nav>
-  <auro-breadcrumb href="http://auro.alaskaair.com/components/auro/nav">Home</auro-breadcrumb>
-  <auro-breadcrumb href="http://auro.alaskaair.com/components/auro/nav">Level 2</auro-breadcrumb>
-  <auro-breadcrumb href="http://auro.alaskaair.com/components/auro/nav">Level 3</auro-breadcrumb>
-  <auro-breadcrumb href="http://auro.alaskaair.com/components/auro/nav">Level 4</auro-breadcrumb>
-  <auro-breadcrumb>Current</auro-breadcrumb>
-</auro-nav>
-```
-<!-- AURO-GENERATED-CONTENT:END -->
-
-## Use CDN
+### Use CDN
 
 <!-- AURO-GENERATED-CONTENT:START (REMOTE:url=https://raw.githubusercontent.com/AlaskaAirlines/auro-templates/main/templates/default/partials/usage/bundleInstallDescription.md) -->
 In cases where the project is not able to process JS assets, there are pre-processed assets available for use. Legacy browsers such as IE11 are no longer supported.
@@ -95,17 +75,7 @@ In cases where the project is not able to process JS assets, there are pre-proce
 
 <!-- AURO-GENERATED-CONTENT:END -->
 
-## auro-nav use cases
-
-<!-- AURO-GENERATED-CONTENT:START (FILE:src=./docs/partials/useCases.md) -->
-<!-- The below content is automatically added from ./docs/partials/useCases.md -->
-The `<auro-nav>` element acts as a container for a series of links representing a level of depth in the site content. 
-The `<auro-nav>` element should only be used for multi-page projects that have 3 to 5 levels of page depth.
-<!-- AURO-GENERATED-CONTENT:END -->
-
-## API Code Examples
-
-### Default auro-nav
+## Basic Example
 
 <!-- AURO-GENERATED-CONTENT:START (CODE:src=./apiExamples/basic.html) -->
 <!-- The below code snippet is automatically added from ./apiExamples/basic.html -->
@@ -121,31 +91,46 @@ The `<auro-nav>` element should only be used for multi-page projects that have 3
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 
-## Development
+## Custom Component Registration for Version Management
 
-<!-- AURO-GENERATED-CONTENT:START (REMOTE:url=https://raw.githubusercontent.com/AlaskaAirlines/auro-templates/main/templates/default/partials/development/developmentDescription.md) -->
-In order to develop against this project, if you are not part of the core team, you will be required to fork the project prior to submitting a pull request.
+There are two key parts to every Auro component: the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes">class</a> and the custom element definition.
+The class defines the component’s behavior, while the custom element registers it under a specific name so it can be used in HTML.
 
-Please be sure to review the [contribution guidelines](https://auro.alaskaair.com/contributing) for this project. Please make sure to **pay special attention** to the **conventional commits** section of the document.
+When you install the component as described on the `Install` page, the class is imported automatically, and the component is registered globally for you.
 
+However, if you need to load multiple versions of the same component on a single page (for example, when two projects depend on different versions), you can manually register the class under a custom element name to avoid conflicts.
+
+You can do this by importing only the component class and using the `register(name)` method with a unique name:
+
+<!-- AURO-GENERATED-CONTENT:START (FILE:src=./docs/partials/customRegistration.md) -->
+<!-- The below content is automatically added from ./docs/partials/customRegistration.md -->
+<!-- add custom registration content here -->
 <!-- AURO-GENERATED-CONTENT:END -->
+<div class="exampleWrapper exampleWrapper--flex">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./apiExamples/custom.html) -->
+  <!-- The below content is automatically added from ./apiExamples/custom.html -->
+  <custom-nav>
+    <custom-breadcrumb href="http://auro.alaskaair.com/components/auro/nav">Home</custom-breadcrumb>
+    <custom-breadcrumb href="http://auro.alaskaair.com/components/auro/nav">Level 2</custom-breadcrumb>
+    <custom-breadcrumb href="http://auro.alaskaair.com/components/auro/nav">Level 3</custom-breadcrumb>
+    <custom-breadcrumb href="http://auro.alaskaair.com/components/auro/nav">Level 4</custom-breadcrumb>
+    <custom-breadcrumb>Current</custom-breadcrumb>
+  </custom-nav>
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./apiExamples/custom.html) -->
+<!-- The below code snippet is automatically added from ./apiExamples/custom.html -->
 
-### Start development environment
-
-<!-- AURO-GENERATED-CONTENT:START (REMOTE:url=https://raw.githubusercontent.com/AlaskaAirlines/auro-templates/main/templates/default/partials/development/localhost.md) -->
-Once the project has been cloned to your local resource and you have installed all the dependencies you will need to open a shell session to run the **dev server**.
-
-```shell
-$ npm run dev
+```html
+<custom-nav>
+  <custom-breadcrumb href="http://auro.alaskaair.com/components/auro/nav">Home</custom-breadcrumb>
+  <custom-breadcrumb href="http://auro.alaskaair.com/components/auro/nav">Level 2</custom-breadcrumb>
+  <custom-breadcrumb href="http://auro.alaskaair.com/components/auro/nav">Level 3</custom-breadcrumb>
+  <custom-breadcrumb href="http://auro.alaskaair.com/components/auro/nav">Level 4</custom-breadcrumb>
+  <custom-breadcrumb>Current</custom-breadcrumb>
+</custom-nav>
 ```
-
-Open [localhost:8000](http://localhost:8000/)
-
 <!-- AURO-GENERATED-CONTENT:END -->
-
-### Testing
-
-<!-- AURO-GENERATED-CONTENT:START (REMOTE:url=https://raw.githubusercontent.com/AlaskaAirlines/auro-templates/main/templates/default/partials/development/testing.md) -->
-Automated tests are required for every Auro component. See `.\test\auro-nav.test.js` for the tests for this component. Run `npm run test` to run the tests and check code coverage. Tests must pass and meet a certain coverage threshold to commit. See [the testing documentation](https://auro.alaskaair.com/support/tests) for more details.
-
-<!-- AURO-GENERATED-CONTENT:END -->
+</auro-accordion>

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -5,8 +5,12 @@
 
 ### Breadcrumb
 
-Example when the `auro-nav` slot is populated with `auro-nav-breadcrumb` elements. The last `auro-nav-breadcrumb` in an `auro-nav` component should represent
+Example when the `auro-nav` slot is populated with `auro-breadcrumb` elements. The last `auro-breadcrumb` in an `auro-nav` component should represent
 the current page the user is on. It should reflect a disabled hyperlink and the `href` attribute should **NOT** be populated.
+
+#### Mobile Behavior
+
+On mobile viewports (576px and under), `auro-nav` will collapse to show only the previous page `auro-breadcrumb` with a back arrow.
 
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/breadcrumb.html) -->

--- a/src/styles/style-breadcrumb.scss
+++ b/src/styles/style-breadcrumb.scss
@@ -88,6 +88,6 @@
 // Hides all breadcrumbs besides the second to last one
 :host(:not(:nth-last-of-type(2))) {
   @include bp.auro_breakpoint($max: vac.$ds-grid-breakpoint-sm) {
-    display: none;
+    display: none !important; // need to override inline-flex from :host
   }
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

An `!important` flag on the display property was preventing `display: none` from being set on mobile viewports. This was preventing the Breadcrumb list from going down to one link on mobile viewports. 

Added `!important` to `display: none` to ensure proper styles are being set at mobile sizes.

This PR also contains some automatic docs updates from auro-cli.


## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-nav/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Ensure breadcrumb items hide correctly on small viewports and refresh documentation for the auro-nav component.

Bug Fixes:
- Force breadcrumb items to use `display: none` on small viewports so only the intended link remains visible on mobile.

Documentation:
- Restructure and update the README with a new use cases section, refreshed install and usage headings, a basic example section, and guidance on custom component registration with code samples.